### PR TITLE
fix broken links

### DIFF
--- a/bi-platform/dashboard.mdx
+++ b/bi-platform/dashboard.mdx
@@ -65,8 +65,8 @@ That will open the Manage Dashboard modal which allows you to edit the title of 
 
 ### Next Steps
 
-Now that you've created a dashboard, you're ready to create your first report! Check out our guides on how to create your first chart below.
+Now that you've created a dashboard, you're ready to create your first report! Check out our guide on how to create one below.
 
-<Card title="Create a chart" icon="square-1" href={"/bi-platform/report"}>
-  Build your first dashboard with Quill in less than a minute.
+<Card title="Create a report" icon="square-1" href={"/bi-platform/report"}>
+  Build your first report with Quill in less than a minute.
 </Card>

--- a/bi-platform/quickstart.mdx
+++ b/bi-platform/quickstart.mdx
@@ -128,7 +128,7 @@ Go to [https://app.quill.co/onboard](https://app.quill.co/onboard) and enter the
 
 <Info>
   For more information about data and access control, you can read our
-  self-hosting guide [here](/selfhost/quickstart.mdx).
+  self-hosting guide [here](/bi-platform/self-host).
 </Info>
 
 ### 3. Connect your schema

--- a/bi-platform/report.mdx
+++ b/bi-platform/report.mdx
@@ -63,7 +63,7 @@ Here, you can edit the name of the chart, the dashboard this chart should belong
 
 <Tip>
   For a more detailed guide for each of each option, see [Editing a
-  Chart](#editing-a-chart) below.
+  Report](#editing-a-report) below.
 </Tip>
 
 ## No Code (ReportBuilder)
@@ -90,7 +90,7 @@ To apply one- or two-dimensional groupings or aggregations you can add a pivot w
 
 You can sort the data in the report by one or more columns using the sort feature and you can limit the number of rows returned in the report using the limit feature.
 
-### 3. Edit the report
+### 3. Edit the chart
 
 Once you are satisfied with your query and the query results, click `Add to dashboard` in the bottom right to turn the query into a report.
 
@@ -146,5 +146,5 @@ With chart and a dashboard, you're ready to start using Quill. If you'd like, yo
   icon="square-1"
   href={"/bi-platform/virtual-table"}
 >
-  Add a SQL view with Quill in less than a minute.
+  Add a virtual table to Quill virtual schema.
 </Card>

--- a/bi-platform/self-host.mdx
+++ b/bi-platform/self-host.mdx
@@ -56,7 +56,7 @@ function App() {
 }
 ```
 
-The add two routes in your app, one for each page of the BI Platform. Use your existing navigation system, but here is an example using react router.
+Then, add two routes in your app, one for each page of the BI Platform. Use your existing navigation system, but here is an example using react router.
 
 ```js App.js
 import {

--- a/bi-platform/tenant.mdx
+++ b/bi-platform/tenant.mdx
@@ -3,7 +3,7 @@ title: "Create a tenant"
 description: "Create objects that own dashboards and can view dashboards owned by other tenants"
 ---
 
-Tenants do two things in the Quill platform. 1. separate data in a dashboard 2. allow certain organizations, users, etc to see specific reports in a dashboard. To learn more about tenancy read more [here](/bi-platform/overview).
+Tenants do two things in the Quill platform. 1. separate data in a dashboard 2. allow certain organizations, users, etc to see specific reports in a dashboard. To learn more about tenancy read more [here](/bi-platform/overview#2-tenant).
 
 <Callout type="info">
   Tenants are the core concept for multi-tenancy in Quill. Each tenant

--- a/react/dashboard.mdx
+++ b/react/dashboard.mdx
@@ -23,7 +23,7 @@ zero-code updates to your dashboard on an org-level as well as company-wide.
 
 <Tip>
   Don't have a dashboard name yet? Learn how to [create a
-  dashboard](https://docs.quillsql.com/bi-plaform/chart) in the Quill BI
+  dashboard](/bi-platform/dashboard) in the Quill BI
   Platform to get started.
 </Tip>
 

--- a/react/headless.mdx
+++ b/react/headless.mdx
@@ -22,8 +22,6 @@ But leave the UI completely up to you.
 
 — [**TanStack**](https://tanstack.com/table/v8/docs/introduction)
 
-![Quill Architecture](/images/quillarchitecture.png)
-
 ## Popular Libraries that leverage React Hooks
 
 - [TanStack Table (useReactTable)](https://tanstack.com/table/latest)

--- a/react/report-builder.mdx
+++ b/react/report-builder.mdx
@@ -1402,7 +1402,7 @@ function App() {
 <ParamField path='reportId' type='string'>
 	A report id that the Report Builder will query from and modify.
 
-    <Tip>See the [report id example](/components/report-builder#edit-an-existing-report) to see an example of how this is used.</Tip>
+    <Tip>See the [report id example](#edit-an-existing-report) to see an example of how this is used.</Tip>
 
 </ParamField>
 

--- a/react/themes.mdx
+++ b/react/themes.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 <Tip>
 	For pixel-perfect control over theming and styling, all Quill components
 	accept custom components as props. See our [dashboard
-	docs](/components/dashboard.mdx) for an example.
+	docs](/react/dashboard) for an example.
 </Tip>
 
 ```tsx App.tsx

--- a/react/use-export.mdx
+++ b/react/use-export.mdx
@@ -33,7 +33,7 @@ function App() {
 	The id of the report you created in the Quill BI Platform.
 
     <Tip>
-    	Don't have an id yet? Learn how to [create a report](https://docs.quillsql.com/bi-platform/report) in the Quill BI Platform to get started.
+    	Don't have an id yet? Learn how to [create a report](/bi-platform/report) in the Quill BI Platform to get started.
     </Tip>
 
 </ParamField>

--- a/react/use-quill.mdx
+++ b/react/use-quill.mdx
@@ -54,7 +54,7 @@ function App() {
 	The id of the report you created in the Quill BI Platform.
 
     <Tip>
-    	Don't have an id yet? Learn how to [create a chart](https://docs.quillsql.com/bi-platform/report) in the Quill BI Platform to get started.
+    	Don't have an id yet? Learn how to [create a chart](/bi-platform/report) in the Quill BI Platform to get started.
     </Tip>
 
 </ParamField>

--- a/server/quickstart.mdx
+++ b/server/quickstart.mdx
@@ -209,6 +209,6 @@ function App() {
 ```
 
 <Tip>
-  See the `QuillProvider` [API docs](/components/quill-provider) for more
+  See the `QuillProvider` [API docs](/react/quill-provider) for more
   information.
 </Tip>


### PR DESCRIPTION
Also fixes one typo

---

🔗 This PR fixes broken internal links and corrects inconsistent terminology across the Quill documentation. The changes ensure proper navigation between documentation sections and standardize the use of "report" vs "chart" terminology throughout the codebase.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Link Corrections**: Fixed broken internal links across 12 documentation files, updating paths from incorrect formats like `/selfhost/quickstart.mdx` to proper ones like `/bi-platform/self-host`
- **Terminology Standardization**: Corrected inconsistent usage between "chart" and "report" throughout the documentation to maintain consistency
- **Content Updates**: Updated card descriptions and section references to accurately reflect current functionality
- **Minor Text Fixes**: Fixed a typo changing "The add" to "Then, add" in the self-host documentation

### Technical Implementation
```mermaid
flowchart TD
    A[Documentation Files] --> B[Link Validation]
    B --> C[Path Corrections]
    C --> D[Terminology Alignment]
    D --> E[Content Consistency]
    
    F[Broken Links] --> G[Fixed Internal References]
    H[Mixed Terminology] --> I[Standardized Language]
    J[Outdated Descriptions] --> K[Updated Content]
```

### Impact
- **User Experience**: Eliminates frustrating broken links that would prevent users from navigating the documentation effectively
- **Documentation Quality**: Ensures consistent terminology and accurate cross-references throughout the entire documentation suite
- **Maintenance**: Reduces confusion for both users and maintainers by standardizing language and fixing navigation issues

</details>

_Created with [Palmier](https://www.palmier.io)_