### PR TITLE
Remove server/quickstart.mdx from Mintlify quickstart fixes diff

### DIFF
--- a/server/quickstart.mdx
+++ b/server/quickstart.mdx
@@ -15,15 +15,15 @@ pip3 install quillsql
 ```
 
 ```bash Go
-go get github.com/quill-sql/quill-go
+go get https://github.com/quill-sql/quill-go
 ```
 
 ```bash PHP
-composer require quill-sql/quill-php
+composer require quill.co/quill-php
 ```
 
 ```bash Ruby
-gem install quill-sql
+bundle install quill-sql
 ```
 
 </CodeGroup>
@@ -32,20 +32,13 @@ gem install quill-sql
 
 Instantiate `Quill` with your credentials and add the below `POST` endpoint.
 
-<Note>
-  The Node.js, Python, and Ruby SDKs accept a multi-tenant `tenants` array of
-  `{ tenantField, tenantIds }` objects. The Go SDK currently uses a single
-  positional `OrgId` (string) and is therefore single-tenant per request. PHP
-  follows the same single-`orgId` shape as Go.
-</Note>
-
 <CodeGroup>
 
 ```js Node
 import { Quill } from "@quillsql/node";
 
 const quill = new Quill({
-  privateKey: process.env.QUILL_PRIVATE_KEY,
+  privateKey: process.env.QULL_PRIVATE_KEY,
   databaseConnectionString: process.env.POSTGRES_READ,
   databaseType: "postgresql",
 });
@@ -56,7 +49,7 @@ app.post("/quill", authenticateJWT, async (req, res) => {
   const { userId } = req.user;
   const { metadata } = req.body;
   const result = await quill.query({
-    tenants: [{ tenantField: "user_id", tenantIds: [userId] }],
+    tenants: [{ tenantField: "user_id", tenantIds: [userId] }]
     metadata,
   });
   res.send(result);
@@ -67,7 +60,7 @@ app.post("/quill", authenticateJWT, async (req, res) => {
 from quillsql import Quill
 
 quill = Quill(
-    private_key=os.getenv("QUILL_PRIVATE_KEY"),
+    private_key=os.getenv("QULL_PRIVATE_KEY"),
     database_connection_string=os.getenv("POSTGRES_READ"),
     database_type="postgresql"
 )
@@ -160,9 +153,9 @@ if ($requestMethod === 'POST' && $endpoint === '/quill') {
 require "quill-sql"
 
 quill = Quill.new(
-  private_key: ENV["QUILL_PRIVATE_KEY"],
-  database_connection_string: ENV["POSTGRES_READ"],
-  database_type: "postgresql"
+  private_key: ENV["PRIVATE_KEY"],
+  database_connection_string: ENV["DB_URL"],
+  database_type: "clickhouse"
 )
 
 post "/quill" do
@@ -197,7 +190,7 @@ function App() {
 
   return (
     <QuillProvider
-      publicKey={process.env.QUILL_PUBLIC_KEY}
+      publicKey="YOUR_PUBLIC_KEY"
       queryEndpoint="https://yourserver.com/quill" // your POST endpoint
       queryHeaders={{
         // We'll pass these headers on every request to your endpoint


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This branch is based on `mintlify/server-quickstart-fixes-1778042435` and restores `server/quickstart.mdx` to match `main`, so that file no longer appears in the PR diff.

All other documentation updates from the Mintlify branch are unchanged. Use this if you want to land the rest of the fixes without modifying the server quickstart page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8abf6f47-7c24-4c2a-a87e-fb0f0ab3ad8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8abf6f47-7c24-4c2a-a87e-fb0f0ab3ad8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

